### PR TITLE
Fixed Eigen headers

### DIFF
--- a/ros/ndt_radar_slam/include/ndt_representation/ndt_cell.h
+++ b/ros/ndt_radar_slam/include/ndt_representation/ndt_cell.h
@@ -171,5 +171,5 @@ class Cell {
 }
 }
 }
-
 #endif
+

--- a/ros/ndt_radar_slam/include/ndt_slam/ndt_slam_parameters.h
+++ b/ros/ndt_radar_slam/include/ndt_slam/ndt_slam_parameters.h
@@ -2,6 +2,7 @@
 #define NDT_SLAM_PARAMETERS_H
 
 #include <Eigen/Core>
+#include <Eigen/Eigenvalues>
 
 namespace rc {
 namespace navigation {
@@ -170,3 +171,4 @@ struct Parameters {
 
 }}}
 #endif
+

--- a/ros/ndt_radar_slam/src/ndt_representation/ndt_cell.cpp
+++ b/ros/ndt_radar_slam/src/ndt_representation/ndt_cell.cpp
@@ -189,3 +189,4 @@ void Cell::clearCell(void) {
 }
 }
 }
+


### PR DESCRIPTION
Eigenvalues model headers are not included by default. They are needed to be included explicitly to avoid initialization errors in source-compiled ROS deployments (at least), and also to increase compatibility.

To preserve structure understanding, the include command was added in the same place where the `Core` module is included.